### PR TITLE
Update setup.py, add exclude for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/mdz/python-smarttub",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages("tests","tests.*"),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
otherwise build will fail, it tries to install a packages "tests" at top level:

```
>>> Jobs: 1 of 2 complete, 1 failed                 Load avg: 1.04, 0.69, 0.65
 * Package:    dev-python/python-smarttub-0.0.12
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   mdz@alcor.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking python-smarttub-0.0.12.tar.gz to /var/tmp/portage/dev-python/python-smarttub-0.0.12/work
>>> Source unpacked in /var/tmp/portage/dev-python/python-smarttub-0.0.12/work
>>> Preparing source in /var/tmp/portage/dev-python/python-smarttub-0.0.12/work/python-smarttub-0.0.12 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/python-smarttub-0.0.12/work/python-smarttub-0.0.12 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/python-smarttub-0.0.12/work/python-smarttub-0.0.12 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
running install_egg_info
running egg_info
writing python_smarttub.egg-info/PKG-INFO
writing dependency_links to python_smarttub.egg-info/dependency_links.txt
writing requirements to python_smarttub.egg-info/requires.txt
writing top-level names to python_smarttub.egg-info/top_level.txt
reading manifest file 'python_smarttub.egg-info/SOURCES.txt'
writing manifest file 'python_smarttub.egg-info/SOURCES.txt'
Copying python_smarttub.egg-info to /var/tmp/portage/dev-python/python-smarttub-0.0.12/image/_python3.8/usr/lib/python3.8/site-packages/python_smarttub-0.0.12-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/python-smarttub-0.0.12::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 ```