### PR TITLE
Update aiohttp constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "aiohttp~=3.7.3",
+        "aiohttp>=3.7.4,<4",
         "inflection~=0.5.1",
         "pyjwt~=2.1.0",
         "python-dateutil~=2.8.1",


### PR DESCRIPTION
`aiohttp-3.8.0` was released a while ago. `aiohttp >= 3.7.4` to avoid CVE-2021-21330