### PR TITLE
Add HIGH_SPEED_WHEEL to color options

### DIFF
--- a/smarttub/api.py
+++ b/smarttub/api.py
@@ -429,7 +429,7 @@ class SpaPump:
 class SpaLight:
     LightMode = Enum(
         "LightMode",
-        "PURPLE ORANGE RED YELLOW GREEN AQUA BLUE WHITE AMBER HIGH_SPEED_COLOR_WHEEL FULL_DYNAMIC_RGB OFF",
+        "PURPLE ORANGE RED YELLOW GREEN AQUA BLUE WHITE AMBER HIGH_SPEED_COLOR_WHEEL HIGH_SPEED_WHEEL FULL_DYNAMIC_RGB OFF",
     )
 
     def __init__(self, spa: Spa, **properties):


### PR DESCRIPTION
When using my Sundance Chelsee hot tub on the multi-color option, I get an error in the HA logs `KeyError: 'HIGH_SPEED_WHEEL'`

Running this command `python -m smarttub -u yyyy -p xxxx -vv info --lights` show the following results (followed by the same KeyError.

`DEBUG:smarttub.api:GET spas/#########/lights successful: {'lights': [{'zone': 1, 'mode': 'HIGH_SPEED_WHEEL', 'cycleSpeed': 2, 'color': {'red': 255, 'blue': 0, 'green': 0, 'white': 0}, 'intensity': 50, 'lastUpdated': '2022-03-16T03:23:29.121Z', 'createdBy': 'SYSTEM'}]}`