### PR TITLE
expose cycleSpeed for color changing lights

### DIFF
--- a/smarttub/api.py
+++ b/smarttub/api.py
@@ -465,6 +465,7 @@ class SpaLight:
 
         self.intensity = properties["intensity"]
         self.mode = self.LightMode[properties["mode"]]
+        self.cycleSpeed = properties["cycleSpeed"]
         self.properties = properties
 
     async def set_mode(self, mode: LightMode, intensity: int):
@@ -480,7 +481,7 @@ class SpaLight:
         await self.set_mode(self.LightMode.OFF, 0)
 
     def __str__(self):
-        return f"<SpaLight {self.zone}: {self.mode.name} (R {self.red}/G {self.green}/B {self.blue}/W {self.white}) @ {self.intensity}>"
+        return f"<SpaLight {self.zone}: {self.mode.name} {self.cycleSpeed} (R {self.red}/G {self.green}/B {self.blue}/W {self.white}) @ {self.intensity}>"
 
 
 class SpaReminder:


### PR DESCRIPTION
Lights that have mode COLOR_WHEEL also have a speed

```
{   'color': {'blue': 0, 'green': 0, 'red': 0, 'white': 0},
    'cycleSpeed': 3,
    'exterior': False,
    'intensity': 60,
    'irt': None,
    'mode': 'COLOR_WHEEL',
    'zone': 1}
```