### PR TITLE
Fix python-dateutil dependency constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "aiohttp>=3.9.1",
     "inflection~=0.5.1",
     "pyjwt>=2.10.0",
-    "python-dateutil~=2.8.1"
+    "python-dateutil>=2.8.1"
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1259,7 +1259,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "python-dateutil", specifier = "~=2.8.1" },
+    { name = "python-dateutil", specifier = ">=2.8.1" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
This PR fixes the python-dateutil dependency constraint to allow newer versions.

**Changes:**
- Changed `python-dateutil~=2.8.1` to `python-dateutil>=2.8.1` in pyproject.toml

**Reason:**
The restrictive constraint `~=2.8.1` only allows python-dateutil 2.8.x versions, but some downstream packages require newer versions (e.g., pyflick==1.1.3 requires >=2.9.0.post0), causing dependency conflicts.

This change maintains backward compatibility while allowing newer python-dateutil versions needed by downstream projects.