### PR TITLE
Migrate authentication from Auth0 to SmartTub IDP

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
-import aiohttp
-import time
+import base64
+import datetime
+import json
 
-import jwt
+import aiohttp
 import pytest
 
 import smarttub
@@ -11,8 +12,32 @@ ACCOUNT_ID = "account_id1"
 pytestmark = pytest.mark.asyncio
 
 
+def make_id_token(account_id: str) -> str:
+    """Create a mock ID token with the account_id claim."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(
+        b"="
+    )
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"custom:account_id": account_id}).encode()
+    ).rstrip(b"=")
+    signature = base64.urlsafe_b64encode(b"fakesignature").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{signature.decode()}"
+
+
+def make_login_response(account_id: str, expires_in: int = 86400) -> dict:
+    """Create a mock login response."""
+    return {
+        "token": {
+            "access_token": "access_token_123",
+            "refresh_token": "refresh_token_123",
+            "id_token": make_id_token(account_id),
+            "expires_in": expires_in,
+        }
+    }
+
+
 @pytest.fixture(name="unauthenticated_api")
-async def unauthenticated_api(aresponses):
+async def unauthenticated_api():
     async with aiohttp.ClientSession() as session:
         yield smarttub.SmartTub(session)
 
@@ -21,53 +46,81 @@ async def unauthenticated_api(aresponses):
 async def api(unauthenticated_api, aresponses):
     api = unauthenticated_api
     aresponses.add(
-        response={
-            "access_token": jwt.encode(
-                {api.AUTH_ACCOUNT_ID_KEY: ACCOUNT_ID, "exp": time.time() + 3600},
-                "secret",
-            ),
-            "token_type": "Bearer",
-            "refresh_token": "refresh1",
-        }
+        response=aresponses.Response(
+            body=json.dumps(make_login_response(ACCOUNT_ID)),
+            status=201,
+            content_type="application/json",
+        )
     )
     await api.login("username1", "password1")
     return api
 
 
-async def test_login(api, aresponses):
+async def test_login(api):
     assert api.account_id == ACCOUNT_ID
-    assert api.logged_in is True
+    assert api._access_token == "access_token_123"
+    assert api._username == "username1"
+    assert api._password == "password1"
 
 
-async def test_login_failed(api, aresponses):
-    aresponses.add(response=aresponses.Response(status=403))
-    with pytest.raises(smarttub.LoginFailed):
-        await api.login("username", "password")
-
-
-async def test_refresh_token(api, aresponses):
-    now = time.time()
-    api.token_expires_at = now
+async def test_login_failed_400(unauthenticated_api, aresponses):
     aresponses.add(
-        response={
-            "access_token": jwt.encode(
-                {api.AUTH_ACCOUNT_ID_KEY: ACCOUNT_ID, "exp": now + 3601},
-                "secret",
-            ),
-        }
+        response=aresponses.Response(
+            body=json.dumps({"message": "Invalid credentials"}),
+            status=400,
+            content_type="application/json",
+        )
     )
-    aresponses.add(response={"status": "OK"})
+    with pytest.raises(smarttub.LoginFailed):
+        await unauthenticated_api.login("username", "password")
+
+
+async def test_login_failed_401(unauthenticated_api, aresponses):
+    aresponses.add(
+        response=aresponses.Response(
+            body=json.dumps([{"description": "Bad request", "type": "ERROR"}]),
+            status=401,
+            content_type="application/json",
+        )
+    )
+    with pytest.raises(smarttub.LoginFailed):
+        await unauthenticated_api.login("username", "password")
+
+
+async def test_token_reauth_on_expiry(api, aresponses):
+    """Test that we re-authenticate when the token expires."""
+    # Expire the token
+    api._token_expires_at = datetime.datetime.now() - datetime.timedelta(seconds=1)
+
+    # Mock the re-login response
+    aresponses.add(
+        response=aresponses.Response(
+            body=json.dumps(make_login_response(ACCOUNT_ID)),
+            status=201,
+            content_type="application/json",
+        )
+    )
+    # Mock the actual API request
+    aresponses.add(
+        response=aresponses.Response(
+            body=json.dumps({"status": "OK"}),
+            status=200,
+            content_type="application/json",
+        )
+    )
+
     response = await api.request("GET", "/")
-    assert api.token_expires_at > now
+    assert api._token_expires_at > datetime.datetime.now()
     assert response.get("status") == "OK"
 
 
 async def test_get_account(api, aresponses):
     aresponses.add(
-        response={
-            "id": "id1",
-            "email": "email1",
-        }
+        response=aresponses.Response(
+            body=json.dumps({"id": "id1", "email": "email1"}),
+            status=200,
+            content_type="application/json",
+        )
     )
 
     account = await api.get_account()
@@ -81,12 +134,18 @@ async def test_api_error(api, aresponses):
         await api.get_account()
 
 
-async def test_not_logged_in(unauthenticated_api, aresponses):
+async def test_not_logged_in(unauthenticated_api):
     with pytest.raises(RuntimeError):
         await unauthenticated_api.request("GET", "/")
 
 
-async def test_request(api, aresponses):
-    aresponses.add(response=aresponses.Response(text=None, status=200))
+async def test_request_empty_response(api, aresponses):
+    aresponses.add(
+        response=aresponses.Response(
+            body="",
+            status=200,
+            headers={"content-length": "0"},
+        )
+    )
     response = await api.request("GET", "/")
     assert response is None


### PR DESCRIPTION
## Summary

SmartTub moved new user accounts to their own IDP endpoint, breaking authentication for these accounts. This change migrates from Auth0 to the new SmartTub IDP.

## Changes

- **New endpoint**: `https://api.smarttub.io/idp/signin` (was Auth0 `/oauth/token`)
- **New response format**: Tokens now wrapped in `{"token": {...}}`
- **Account ID**: Extracted from `custom:account_id` claim in ID token (was Auth0 claim)
- **Token refresh**: Since no refresh endpoint exists, stores credentials and re-authenticates when token expires (24h)
- **Removed**: `jwt` dependency (manually decode ID token for account_id)

## Testing

- [x] Unit tests updated and passing
- [x] Live tested against real API
- [x] Re-authentication flow tested (forced token expiry triggers successful re-auth)

Fixes home-assistant/core#156317

Thanks @xags for the patch